### PR TITLE
Fixes for rust nightly change to behavior of no_std

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,13 +21,11 @@
 //! the system libc library.
 
 #![no_std]
-#![feature(no_std, core)]
+#![feature(no_std)]
 
 // This library defines the builtin functions, so it would be a shame for
 // LLVM to optimize these function calls to themselves!
 #![no_builtins]
-
-extern crate core;
 
 #[cfg(test)] #[macro_use] extern crate std;
 


### PR DESCRIPTION
As described at https://github.com/rust-lang/rfcs/pull/1184, new rust nightlies automatically import core when no_std is active
