### PR TITLE
Rename thumbv6-none-eabi target to thumbv6m-none-eabi

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ environments where another libc does not exist, since rustc may
 implicitly insert calls to such functions.
 """
 
-[target.thumbv6-none-eabi.dependencies.core]
+[target.thumbv6m-none-eabi.dependencies.core]
 git = "https://github.com/hackndev/rust-libcore"
 
 [target.thumbv7m-none-eabi.dependencies.core]


### PR DESCRIPTION
Cortex-M0 processors have ARMv6-M architecture. LLVM distinguishes from
ARMv6 by the "m" suffix on the architecture part of the target triplet.
For details, see "ARMSubArch_v6" and "ARMSubArch_v6m" from "enum
SubArchType" and the triplet normalization logic in LLVM sources.

See http://llvm.org/viewvc/llvm-project?view=revision&revision=232469
for a diagram showing this difference.

Note that this will require related changes to zinc repository (PR will be submitted shortly).
