### PR TITLE
Upstream release 0.1.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 
 name = "rlibc"
-version = "0.1.3"
+version = "0.1.4"
 authors = ["The Rust Project Developers"]
 
 license = "MIT/Apache-2.0"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Add this to your `Cargo.toml`:
 ```toml
 [dependencies]
 
-rlibc = "*"
+rlibc = "0.1"
 ```
 
 And add this to your crate root:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,14 +21,12 @@
 //! the system libc library.
 
 #![no_std]
-#![feature(no_std, core)]
+#![feature(no_std)]
 #![cfg_attr(test, feature(core_str_ext, core_slice_ext))]
 
 // This library defines the builtin functions, so it would be a shame for
 // LLVM to optimize these function calls to themselves!
 #![no_builtins]
-
-extern crate core;
 
 #[cfg(test)] #[macro_use] extern crate std;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 
 #![no_std]
 #![feature(no_std, core)]
+#![cfg_attr(test, feature(core_str_ext, core_slice_ext))]
 
 // This library defines the builtin functions, so it would be a shame for
 // LLVM to optimize these function calls to themselves!


### PR DESCRIPTION
This merges the upstream [`0.1.4` release](https://crates.io/crates/rlibc/0.1.4) in to our `zinc` branch.

Previously, I'd been rebasing the _whole_ branch off of the new release each time it happened, but since we're starting to accumulate a meaningful number of commits in our branch I say we just start merging releases in.

I guess I'd just like to **RFC** how we're going to manage this fork going forward (see alternatives to this release-merging scheme below).
# Alternatives

Alternatively, we could just squash down our branch and basically just treat our branch as a constantly updating patch, but that could get painful with large rebases down the road (unless we really squash the commits -- as I bet most of them only conflict with each other, not upstream due to the nature of our changes; we're only really fighting build system caveats).
